### PR TITLE
Update successful scan haptics to be configurable 

### DIFF
--- a/QKMRZScanner/QKMRZScannerView.swift
+++ b/QKMRZScanner/QKMRZScannerView.swift
@@ -27,10 +27,8 @@ public class QKMRZScannerView: UIView {
     fileprivate var isScanningPaused = false
     fileprivate var observer: NSKeyValueObservation?
     @objc public dynamic var isScanning = false
+    public var vibrateOnResult = true
     public weak var delegate: QKMRZScannerViewDelegate?
-    
-    /// If true device will vibrate on a successful scan
-    public var hapticsOnSuccess: Bool = true
     
     public var cutoutRect: CGRect {
         return cutoutView.cutoutRect
@@ -285,7 +283,7 @@ extension QKMRZScannerView: AVCaptureVideoDataOutputSampleBufferDelegate {
                         let enlargedDocumentImage = self.enlargedDocumentImage(from: cgImage)
                         let scanResult = QKMRZScanResult(mrzResult: mrzResult, documentImage: enlargedDocumentImage)
                         self.delegate?.mrzScannerView(self, didFind: scanResult)
-                        if self.hapticsOnSuccess {
+                        if self.vibrateOnResult {
                             AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
                         }
                     }

--- a/QKMRZScanner/QKMRZScannerView.swift
+++ b/QKMRZScanner/QKMRZScannerView.swift
@@ -29,6 +29,9 @@ public class QKMRZScannerView: UIView {
     @objc public dynamic var isScanning = false
     public weak var delegate: QKMRZScannerViewDelegate?
     
+    /// If true device will vibrate on a successful scan
+    public var hapticsOnSuccess: Bool = true
+    
     public var cutoutRect: CGRect {
         return cutoutView.cutoutRect
     }
@@ -282,7 +285,9 @@ extension QKMRZScannerView: AVCaptureVideoDataOutputSampleBufferDelegate {
                         let enlargedDocumentImage = self.enlargedDocumentImage(from: cgImage)
                         let scanResult = QKMRZScanResult(mrzResult: mrzResult, documentImage: enlargedDocumentImage)
                         self.delegate?.mrzScannerView(self, didFind: scanResult)
-                        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+                        if self.hapticsOnSuccess {
+                            AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Hi 👋 , 

Great library you've got here. 

### Some context
Pretty simple, but for my use case I don't want the device to vibrate on a successful scan. This is because my requirements of optional fields are stricter than the scanner (Dob and Sex can't be optional). That is I want to treat these fields missing as an unsuccessful scan and keep scanning. 
Currently I can work around this easily by calling `startScanning()` when a scan completes but when optional fields I need are are nil. Unfortunately this triggers a vibration (which is a cool feature, but I only want to trigger when I have a successful scan that meets my stricter requirements I can do this myself in the app code). 

### What does this change
It makes the call to AudioServicesPlaySystemSound conditional on a property that is configurable outside of the library. I default this configuration property to true to preserve existing behaviour. 

It'd be fab to get this merged and get a new Cocoapods version released - but open to other ideas for solving my problem :) 