### PR TITLE
Added property to make the cutout view hidden

### DIFF
--- a/QKMRZScanner/QKMRZScannerView.swift
+++ b/QKMRZScanner/QKMRZScannerView.swift
@@ -29,6 +29,11 @@ public class QKMRZScannerView: UIView {
     @objc public dynamic var isScanning = false
     public var vibrateOnResult = true
     public weak var delegate: QKMRZScannerViewDelegate?
+    public var isCutoutViewHidden = false {
+        didSet {
+            cutoutView.isHidden = isCutoutViewHidden
+        }
+    }
     
     public var cutoutRect: CGRect {
         return cutoutView.cutoutRect
@@ -170,6 +175,8 @@ public class QKMRZScannerView: UIView {
             cutoutView.leftAnchor.constraint(equalTo: leftAnchor),
             cutoutView.rightAnchor.constraint(equalTo: rightAnchor)
         ])
+        
+        cutoutView.isHidden = isCutoutViewHidden
     }
     
     fileprivate func initCaptureSession() {


### PR DESCRIPTION
I would like to add a minor improvement to this library. It's a simple property that will control the visibility of the cutout view.
In the app where we use the scanner we have a requirement to hide the cutout view. Since it's implementation is private and I can't do any modifications/overrides, I decided to add changes to the library directly. It would be great to get this merged. If you have any concerns or ideas let's discuss them 😊 
